### PR TITLE
BF: fix conversion from string to unsigned int for max_iterations

### DIFF
--- a/src/main.cc
+++ b/src/main.cc
@@ -16,6 +16,7 @@
 #include <iostream>
 #include <sstream>
 #include <signal.h>
+#include <stdint.h>
 
 string Env::prefix = "";
 Logger::Level Env::level = Logger::DEBUG;
@@ -216,7 +217,7 @@ main(int argc, char **argv)
     } else if (strcmp(argv[i], "-logl") == 0) {
       logl = true;
     } else if (strcmp(argv[i], "-max-iterations") == 0) {
-      max_iterations = atoi(argv[++i]);
+      sscanf(argv[++i], "%"SCNu32, &max_iterations);
     } else if (strcmp(argv[i], "-no-stop") == 0) {
       use_validation_stop = false;
     } else if (strcmp(argv[i], "-seed") == 0) {


### PR DESCRIPTION
the original implementation used 'atoi' to set uint32_t max_iterations, while 'atoi' returns a signed int. 
