### PR TITLE
fixed compatibility issue g++ compiler fastqueue.hh

### DIFF
--- a/src/fastqueue.hh
+++ b/src/fastqueue.hh
@@ -46,7 +46,8 @@ public:
   double nontop_k_weight() const;
   const KVList &list() const { return _list; }
   
-  static const double THRESH = 0.8;
+  //static const double THRESH = 0.8; 
+  constexpr static double THRESH = 0.8;
   static void static_initialize(uint32_t k, double alpha);
   static uint32_t K() { return _K; }
 


### PR DESCRIPTION
Dear Prem,

Thanks for making SVINET publicly available, very useful! 

Upon building the package with the most recent g++ compiler I got the following error:
fastqueue.hh:49:23: error: 'constexpr' needed for in-class initialization of static data member 'cont double FastQueue::THRESH' of non-integral type [-fpermissive]
49 | static const double THRESH = 0.8;

Probably because I am using the most recent (today) g++ compiler and that changes the const function:
https://en.cppreference.com/w/cpp/language/constexpr

Hence this change so that g++ can build it :).
Many thanks, warm regards,
Mark Patrick Roeling